### PR TITLE
Some updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
 name = "lalrpop"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +351,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,9 +386,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "logos"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c000ca4d908ff18ac99b93a062cb8958d331c3220719c52e77cb19cc6ac5d2c1"
+checksum = "161971eb88a0da7ae0c333e1063467c5b5727e7fb6b710b8db4814eade3a42e8"
 dependencies = [
  "logos-derive",
 ]
@@ -391,23 +403,24 @@ dependencies = [
 
 [[package]]
 name = "logos-codegen"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc487311295e0002e452025d6b580b77bb17286de87b57138f3b5db711cded68"
+checksum = "8e31badd9de5131fdf4921f6473d457e3dd85b11b7f091ceb50e4df7c3eeb12a"
 dependencies = [
  "beef",
  "fnv",
+ "lazy_static",
  "proc-macro2",
  "quote",
- "regex-syntax 0.6.29",
+ "regex-syntax 0.8.2",
  "syn",
 ]
 
 [[package]]
 name = "logos-derive"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbfc0d229f1f42d790440136d941afd806bc9e949e2bcb8faa813b0f00d1267e"
+checksum = "1c2a69b3eb68d5bd595107c9ee58d7e07fe2bb5e360cc85b0f084dedac80de0a"
 dependencies = [
  "logos-codegen",
 ]
@@ -660,15 +673,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rustix"
@@ -690,6 +703,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
+name = "ryu"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,9 +716,41 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.185"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde-json-app"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.196"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "siphasher"

--- a/examples/chumsky-app/app.rs
+++ b/examples/chumsky-app/app.rs
@@ -14,7 +14,7 @@ fn main() {
         .expect("Failed to read file");
 
     let (json, errs) = parser::parser().parse_recovery(src.trim());
-    println!("{:#?}", json);
+    std::hint::black_box(json);
     errs.into_iter().for_each(|e| {
         let msg = if let chumsky::error::SimpleReason::Custom(msg) = e.reason() {
             msg.clone()

--- a/examples/combine-app/app.rs
+++ b/examples/combine-app/app.rs
@@ -14,7 +14,7 @@ fn main() {
     let mut parser = parser::json_value();
     match parser.easy_parse(src.as_bytes()) {
         Ok(json) => {
-            println!("{:#?}", json);
+            std::hint::black_box(json);
         }
         Err(err) => {
             eprintln!("{:#?}", err);

--- a/examples/lalrpop-app/app.rs
+++ b/examples/lalrpop-app/app.rs
@@ -14,7 +14,7 @@ fn main() {
 
     match json::ValueParser::new().parse(&src) {
         Ok(json) => {
-            println!("{:#?}", json);
+            std::hint::black_box(json);
         }
         Err(err) => {
             eprintln!("{}", err);

--- a/examples/logos-app/app.rs
+++ b/examples/logos-app/app.rs
@@ -10,7 +10,9 @@ fn main() {
 
     let mut lexer = parser::Token::lexer(src.as_str());
     match parser::parse_value(&mut lexer) {
-        Ok(json) => println!("{:#?}", json),
+        Ok(json) => {
+            std::hint::black_box(json);
+        }
         Err((msg, span)) => {
             use ariadne::{ColorGenerator, Label, Report, ReportKind, Source};
 

--- a/examples/nom-app/app.rs
+++ b/examples/nom-app/app.rs
@@ -12,7 +12,7 @@ fn main() {
 
     match parser::root::<VerboseError<&str>>(src.as_str()) {
         Ok(json) => {
-            println!("{:#?}", json);
+            std::hint::black_box(json);
         }
         Err(Err::Error(err)) | Err(Err::Failure(err)) => {
             let err = convert_error(src.as_str(), err);

--- a/examples/peg-app/app.rs
+++ b/examples/peg-app/app.rs
@@ -8,7 +8,7 @@ fn main() {
 
     match parser::parser::json(&src) {
         Ok(json) => {
-            println!("{:#?}", json);
+            std::hint::black_box(json);
         }
         Err(err) => {
             eprintln!("{}", err);

--- a/examples/pest-app/app.rs
+++ b/examples/pest-app/app.rs
@@ -20,7 +20,7 @@ fn main() {
 
     match parser::Json::parse(&src) {
         Ok(json) => {
-            println!("{:#?}", json);
+            std::hint::black_box(json);
         }
         Err(err) => {
             eprintln!("{}", err);

--- a/examples/pom-app/app.rs
+++ b/examples/pom-app/app.rs
@@ -8,7 +8,7 @@ fn main() {
 
     match parser::json().parse(src.as_bytes()) {
         Ok(json) => {
-            println!("{:#?}", json);
+            std::hint::black_box(json);
         }
         Err(err) => {
             eprintln!("{}", err);

--- a/examples/serde-json-app/Cargo.toml
+++ b/examples/serde-json-app/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "serde-json-app"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "serde-json-app"
+path = "app.rs"
+
+[dependencies]
+serde_json = "1.0.113"

--- a/examples/serde-json-app/app.rs
+++ b/examples/serde-json-app/app.rs
@@ -4,7 +4,12 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     let src = fs::read_to_string(env::args().nth(1).expect("Expected file argument"))
         .expect("Failed to read file");
 
-    std::hint::black_box(src);
+    match serde_json::from_str::<serde_json::Value>(&src) {
+        Ok(value) => {
+            std::hint::black_box(value);
+        }
+        Err(e) => eprintln!("{e}"),
+    }
 
     Ok(())
 }

--- a/examples/winnow-app/app.rs
+++ b/examples/winnow-app/app.rs
@@ -15,7 +15,7 @@ fn main() {
         .map_err(|e| e.to_string())
     {
         Ok(json) => {
-            println!("{:#?}", json);
+            std::hint::black_box(json);
         }
         Err(err) => {
             eprintln!("{}", err);

--- a/examples/yap-app/app.rs
+++ b/examples/yap-app/app.rs
@@ -8,7 +8,7 @@ fn main() {
 
     match parser::parse(&src) {
         Ok(json) => {
-            println!("{:#?}", json);
+            std::hint::black_box(json);
         }
         Err(err) => {
             eprintln!("{:?}", err);


### PR DESCRIPTION
- Use `std::hint::black_box` instead of `println!("{json:#?}")`
- Update `logos` parser to use a smaller token type
- Add `serde-json` as an example of a well-optimized non-SIMD JSON parser, for comparison.

| Name       | Overhead (release) | Build (debug) | Parse (release) | Version  |
| ---------- | ------------------ | ------------- | --------------- | -------- |
| null       | 0 KiB              | 129ms         | 1ms             | -        |
| chumsky    | 673 KiB            | 3s            | 248ms           | v0.4.0   |
| logos      | 281 KiB            | 2s            | 9ms             | v0.4.0   |
| combine    | 256 KiB            | 2s            | 35ms            | v3.8.1   |
| lalrpop    | 1,651 KiB          | 5s            | 523ms           | v0.20.0  |
| nom        | 106 KiB            | 1s            | 36ms            | v7.1.3   |
| peg        | 26 KiB             | 880ms         | 10ms            | v0.8.2   |
| pest       | 108 KiB            | 2s            | 29ms            | v2.7.6   |
| pom        | 148 KiB            | 828ms         | 476ms           | v3.3.0   |
| serde-json | 48 KiB             | 2s            | 8ms             | v1.0.113 |
| winnow     | 79 KiB             | 900ms         | 13ms            | v0.5.36  |
| yap        | 63 KiB             | 274ms         | 18ms            | v0.12.0  |

_System: Linux 5.15.133.1-microsoft-standard-WSL2 (x86_64) w/ `-j 32`_

The above was generated from [this data](https://gist.github.com/jprochazk/9cdff1f85a6e7ffcda8798b9cedd1ff7) using `format.py`. I removed the downloads column.

Some notes:
- The benchmark should not be measuring the time it takes to start the program and read the input
  - Hyperfine is great, and does a good job filtering out statistical noise, but there is no reason to use it for Rust-only code.
    For the "runtime" part of the benchmark, everything should be in a single `criterion` suite.
- JSON is too simple
  - A good addition would be some sane subset of an ML family language, as those tend to be easy to parse.